### PR TITLE
Production-ready configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "react-dom": "^15.3.0",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
+    "redux-vcr.capture": "^0.1.8",
+    "redux-vcr.persist": "^0.1.8",
+    "redux-vcr.replay": "^0.1.8",
+    "redux-vcr.retrieve": "^0.1.8",
     "todomvc-app-css": "^2.0.6"
   },
   "scripts": {

--- a/src/HOCs/DevToolWrapper/index.js
+++ b/src/HOCs/DevToolWrapper/index.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react'
+
+let DevTools
+if (process.env.NODE_ENV !== 'production') {
+  DevTools = require('../../components/DevTools').default;
+}
+
+const DevToolWrapper = (WrappedComponent) => (
+  class WrappedDevTools extends Component {
+    render() {
+      return (
+        <div>
+          <WrappedComponent {...this.props} />
+          {DevTools ? <DevTools /> : null}
+        </div>
+      )
+    }
+  }
+)
+
+export default DevToolWrapper

--- a/src/components/DevTools.js
+++ b/src/components/DevTools.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Replay } from 'redux-vcr.replay'
+
+
+const DevTools = () => (
+  <div>
+    {/* Other devtools (eg. Redux LogMonitor) can be used here as well */}
+    <Replay />
+  </div>
+)
+
+export default DevTools

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Header from '../components/Header'
 import MainSection from '../components/MainSection'
+import DevToolWrapper from '../HOCs/DevToolWrapper'
 import * as TodoActions from '../actions'
 
 class App extends Component {
@@ -45,7 +46,9 @@ function mapDispatchToProps(dispatch) {
   }
 }
 
+const WrappedApp = DevToolWrapper(App)
+
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(App)
+)(WrappedApp);

--- a/src/data/firebase-auth.js
+++ b/src/data/firebase-auth.js
@@ -1,0 +1,5 @@
+export default {
+  apiKey: "AIzaSyBklunZBwf0YMFbpHWVmfcu2scFAb2gq3o",
+  authDomain: "todomvc-ccb8e.firebaseapp.com",
+  databaseURL: "https://todomvc-ccb8e.firebaseio.com",
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { createStore } from 'redux'
 import { Provider } from 'react-redux'
+
 import App from './containers/App'
-import reducer from './reducers'
+import configureStore from './store/configure-store';
+
 import 'todomvc-app-css/index.css'
 
-const store = createStore(reducer)
+
+const store = configureStore();
 
 render(
   <Provider store={store}>

--- a/src/store/configure-store.dev.js
+++ b/src/store/configure-store.dev.js
@@ -1,0 +1,20 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+
+import { createRetrieveHandler, createRetrieveMiddleware } from 'redux-vcr.retrieve';
+import { createReplayMiddleware, wrapReducer } from 'redux-vcr.replay';
+
+import reducer from '../reducers';
+import firebaseAuth from '../data/firebase-auth';
+
+const retrieveHandler = createRetrieveHandler({ firebaseAuth });
+
+const middlewares = [
+  createRetrieveMiddleware({ retrieveHandler }),
+  createReplayMiddleware(),
+];
+
+const enhancer = applyMiddleware(...middlewares);
+
+export default function configureStore(initialState) {
+  return createStore(wrapReducer(reducer), initialState, enhancer);
+}

--- a/src/store/configure-store.js
+++ b/src/store/configure-store.js
@@ -1,0 +1,6 @@
+if (process.env.NODE_ENV === 'production') {
+  // Use commonjs modules because ES6 doesn't support conditional imports.
+  module.exports = require('./configure-store.prod');
+} else {
+  module.exports = require('./configure-store.dev');
+}

--- a/src/store/configure-store.prod.js
+++ b/src/store/configure-store.prod.js
@@ -1,0 +1,17 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+
+import { createCaptureMiddleware } from 'redux-vcr.capture';
+import { createPersistHandler } from 'redux-vcr.persist';
+
+import reducer from '../reducers';
+import firebaseAuth from '../data/firebase-auth';
+
+const persistHandler = createPersistHandler({ firebaseAuth });
+
+const middlewares = [ createCaptureMiddleware({ persistHandler }) ];
+
+const enhancer = applyMiddleware(...middlewares);
+
+export default function configureStore(initialState) {
+  return createStore(reducer, initialState, enhancer);
+}


### PR DESCRIPTION
This is a typical example of production-ready ReduxVCR configuration.

In development mode, we don't need to worry about recording our sessions. In production, we don't want to include the retrieve or replay logic (this is, after all, a dev tool, and dev tools should not be bundled in production).

This code uses a higher-order component to conditionally load the devtool, because it removes a lot of duplication. However, a more straightforward approach may be to follow [the example in the Redux Devtools documentation](https://github.com/gaearon/redux-devtools/blob/master/docs/Walkthrough.md#exclude-devtools-from-production-builds), and create two copies of your main `App.js` component.
